### PR TITLE
feat(material_generator): Implement RAG pipeline and upgrade graph to plan-and-execute agent

### DIFF
--- a/backend/app/agents/material_generator/exam_nodes.py
+++ b/backend/app/agents/material_generator/exam_nodes.py
@@ -1,89 +1,243 @@
 import os
-from openai import OpenAI
-from typing import List
+import json
+from typing import List, Dict, Any, Tuple, Optional
+from pydantic import BaseModel, Field
+
+# LangChain imports for LLM wrapping and messaging
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage, SystemMessage
+
 from .state import ExamGenerationState
+from app.agents.rag_agent import rag_agent
 
-# Initialize the OpenAI client
+# Initialize the LangChain ChatOpenAI model
+# This wrapper allows for automatic tracing in LangSmith
 try:
-    client = OpenAI()
-    print("OpenAI client initialized successfully.")
+    llm = ChatOpenAI(model="gpt-4-turbo")
+    print("LangChain ChatOpenAI model initialized successfully.")
 except Exception as e:
-    print(f"Failed to initialize OpenAI client: {e}")
-    client = None
+    print(f"Failed to initialize ChatOpenAI model: {e}")
+    llm = None
 
+# --- Pydantic Models for Tool-based Planning ---
+class Task(BaseModel):
+    """A single task for generating questions."""
+    type: str = Field(..., description="The type of task, e.g., 'multiple_choice', 'short_answer', 'true_false'.")
+    count: int = Field(..., description="The number of questions to generate for this task.")
+    topic: Optional[str] = Field(None, description="The specific topic for this task, if any.")
+
+class Plan(BaseModel):
+    """A structured plan consisting of a list of generation tasks."""
+    tasks: List[Task] = Field(..., description="A list of generation tasks to perform based on the user's query.")
+
+
+# --- Node Functions ---
 
 def call_openai_api(prompt: str, images: List[str] = None) -> str:
-    """Calls the OpenAI API with a multimodal payload (text and optional images)."""
-    if not client:
-        raise ConnectionError("OpenAI client is not initialized. Please check your API key.")
+    """Calls the LLM with a multimodal payload using LangChain's wrapper."""
+    if not llm:
+        raise ConnectionError("ChatOpenAI model is not initialized. Please check your API key.")
 
+    # LangChain's HumanMessage can handle multimodal content in a list
     message_content = [{"type": "text", "text": prompt}]
     if images:
         for image_uri in images:
             message_content.append({
                 "type": "image_url",
-                "image_url": {"url": image_uri}
+                "image_url": {
+                    "url": image_uri,
+                    "detail": "low"
+                }
             })
+    
+    messages = [
+        SystemMessage(content="You are a helpful assistant expert in creating educational materials."),
+        HumanMessage(content=message_content)
+    ]
 
-    response = client.chat.completions.create(
-        model="gpt-4-turbo",
-        messages=[
-            {"role": "system", "content": "You are a helpful assistant expert in creating educational materials."},
-            {"role": "user", "content": message_content},
-        ]
-    )
-    return response.choices[0].message.content
+    response = llm.invoke(messages)
+    return response.content
 
+def _prepare_multimodal_content(retrieved_page_content: List[Dict[str, Any]], max_images: int = 5) -> Tuple[str, List[str]]:
+    """
+    (This is the new, efficient version)
+    Prepares content ONLY from structured_page_content.
+    """
+    combined_text_parts = []
+    image_data_urls = []
+    image_source_map = []
+
+    if not retrieved_page_content:
+        return "", []
+
+    for item in retrieved_page_content:
+        if item.get("type") == "structured_page_content":
+            page_num = item.get("page_number", "Unknown") 
+            
+            combined_text_parts.append(f"\n\n--- [START] Source: Page {page_num} ---")
+            
+            page_content = item.get("content", [])
+            for element in page_content:
+                if element.get("type") == "text":
+                    combined_text_parts.append(element.get("content", ""))
+                
+                elif element.get("type") == "image" and len(image_data_urls) < max_images:
+                    base64_data = element.get("base64")
+                    if base64_data:
+                        valid_image_url = None
+                        if base64_data.startswith("data:image"):
+                            valid_image_url = base64_data
+                        else:
+                            mime_type = element.get("mime_type", "image/jpeg")
+                            valid_image_url = f"data:{mime_type};base64,{base64_data}"
+                        
+                        if valid_image_url:
+                            image_data_urls.append(valid_image_url)
+                            image_index = len(image_data_urls)
+                            combined_text_parts.append(f"\n[Image {image_index} is here. Source: Page {page_num}]\n")
+                            image_source_map.append(f"Image {image_index}: Sourced from Page {page_num}")
+
+            combined_text_parts.append(f"--- [END] Source: Page {page_num} ---\n")
+
+    
+    final_text = "\n".join(combined_text_parts)
+    
+    if image_source_map:
+        final_text += "\n\n--- Image Source Key ---\n"
+        final_text += "\n".join(image_source_map)
+        
+    return final_text, image_data_urls
 
 def retrieve_chunks_node(state: ExamGenerationState) -> ExamGenerationState:
-    """
-    Retrieves pre-processed text chunks from the database using unique_content_id.
-    This is a mock implementation for now.
-    """
+    """Retrieves context using RAGAgent and populates the state."""
     print("Node: retrieve_chunks_node")
     try:
-        content_id = state["unique_content_id"]
-        print(f"Simulating fetching chunks for unique_content_id: {content_id}")
-        
-        # In a real implementation, you would query the DOCUMENT_CHUNKS table:
-        # from app.database import SessionLocal
-        # from app.models import DocumentChunk
-        # db = SessionLocal()
-        # chunks = db.query(DocumentChunk).filter(DocumentChunk.unique_content_id == content_id).order_by(DocumentChunk.chunk_order).all()
-        # retrieved_content = "\n\n".join([chunk.chunk_text for chunk in chunks])
-        # db.close()
-
-        # Mock content for demonstration purposes
-        mock_content = f"This is the pre-processed and chunked content for document ID {content_id}. " \
-                       "It was retrieved from the database, not from a raw file. " \
-                       "This new process is much more efficient as it avoids re-reading the file."
-        
-        state["retrieved_content"] = mock_content
-        # TODO: Image handling will also need to be adapted to use the database in the future.
-        # For now, we assume no images are retrieved with chunks.
-        state["document_images"] = [] 
+        rag_results = rag_agent.search(state["query"], state["unique_content_id"])
+        state["retrieved_text_chunks"] = rag_results["text_chunks"]
+        state["retrieved_page_content"] = rag_results["page_content"]
+        state["generation_plan"] = []
+        state["final_generated_content"] = []
         state["error"] = None
     except Exception as e:
-        state["error"] = f"Failed to retrieve chunks from DB: {str(e)}"
+        state["error"] = f"Failed to retrieve context using RAGAgent: {str(e)}"
     return state
 
+def plan_generation_tasks_node(state: ExamGenerationState) -> ExamGenerationState:
+    """
+    Analyzes the user query to create a structured generation plan.
+    This node is now more efficient as it does not require document context.
+    """
+    print("Node: plan_generation_tasks_node (Optimized)")
+
+    if state.get("generation_plan") and len(state.get("generation_plan", [])) > 0:
+        print("Plan already exists, skipping planning.")
+        return state
+    if state.get("final_generated_content"):
+         return state
+
+    # This prompt now only uses the user's query, making it faster and cheaper.
+    prompt = f"""Analyze the user's query to create a step-by-step generation plan.
+
+**User Query:** "{state['query']}"
+
+You must respond by calling the `Plan` tool with the appropriate tasks based on the user's query.
+"""
+    try:
+        # Bind the Pydantic model as a tool for the LLM
+        planner_llm = llm.bind_tools(tools=[Plan], tool_choice="Plan")
+        
+        messages = [
+            SystemMessage(content="You are a helpful assistant that creates a structured generation plan based on a user query."),
+            HumanMessage(content=prompt)
+        ]
+        
+        response = planner_llm.invoke(messages)
+        
+        if not response.tool_calls:
+            raise ValueError("The model did not call the required 'Plan' tool.")
+
+        tool_call = response.tool_calls[0]
+        plan_args = tool_call['args']
+        
+        # Pydantic validation happens here
+        plan = Plan(**plan_args)
+        
+        state["generation_plan"] = [task.model_dump() for task in plan.tasks]
+        print(f"Generated Plan: {state['generation_plan']}")
+
+    except Exception as e:
+        state["error"] = f"Failed to create a generation plan: {e}"
+        print(f"ERROR in plan_generation_tasks_node: {e}")
+        state["generation_plan"] = []
+    return state
+
+def prepare_next_task_node(state: ExamGenerationState) -> ExamGenerationState:
+    """
+    Pops the next task from the plan and sets it as the current task.
+    This node is the entry point for the execution loop.
+    """
+    print("Node: prepare_next_task_node")
+    # Clear previous task's error if any, to avoid premature termination
+    state["error"] = None
+    
+    if state.get("generation_plan") and len(state["generation_plan"]) > 0:
+        next_task = state["generation_plan"].pop(0)
+        state["current_task"] = next_task
+        print(f"Preparing to execute next task: {next_task}")
+    else:
+        print("Generation plan is now empty.")
+        state["current_task"] = None # Explicitly set to None
+    return state
+
+def should_continue_router(state: ExamGenerationState) -> str:
+    """
+    Router that checks the current task and decides where to go next.
+    This function has NO side effects and only performs routing logic.
+    """
+    print("Router: should_continue_router")
+    if state.get("error"):
+        return "handle_error"
+    
+    current_task = state.get("current_task")
+    if current_task:
+        task_type = current_task.get("type")
+        print(f"Routing to: generate_{task_type}")
+        if task_type in ["multiple_choice", "short_answer", "true_false"]:
+            return f"generate_{task_type}"
+        else:
+            # This path should ideally not be taken if planner is correct
+            return "handle_error"
+    else:
+        # No current task, so we end the loop.
+        print("Routing to: end")
+        return "end"
 
 def generate_multiple_choice_node(state: ExamGenerationState) -> ExamGenerationState:
-    """Generates high-quality multiple-choice questions based on provided content."""
+    """Generates multiple-choice questions for the current task in the plan."""
     print("Node: generate_multiple_choice_node")
-    # TODO: The AI's role/persona could be made configurable by the user in the future.
+    
+    # --- DEBUGGING STEP for verification ---
+    current_task = state.get("current_task", {})
+    print(f"--- VERIFY: Received Current Task in generate_multiple_choice_node: {current_task} ---")
+    # --- END DEBUGGING STEP ---
+
+    task_details = f"Task: Generate {current_task.get('count', 1)} multiple choice question(s)"
+    if current_task.get('topic'):
+        task_details += f" about '{current_task.get('topic')}'"
+    combined_retrieved_text, image_data_urls = _prepare_multimodal_content(state["retrieved_page_content"])
     prompt = f"""You are a professional university professor (您是一位專業的大學教師) designing an exam. Your task is to generate high-quality multiple-choice questions based on the provided text content and images.
 
 **--- CRITICAL PRINCIPLES ---**
 1.  **Must Provide Correct Answer:** Every question must have a clearly indicated correct answer.
 2.  **Must Cite Source:** For each question, you MUST specify where the answer can be found (e.g., "Source: Page 5, Paragraph 2" or "Source: Figure 1").
 3.  **Language:** All output must be in Traditional Chinese (繁體中文).
-4.  **Subject Relevance:** All questions must be strictly relevant to the main subject of the document. Filter out any questions not related to the core professional topic.
+4.  **Subject Relevance:** All questions must be strictly relevant to the main subject of the document.
 
 **--- INPUTS ---**
-- **User Query:** {state['query']}
+- **Overall User Query:** {state['query']}
+- **Current Task:** {task_details}
 - **Retrieved Content:**
-{state['retrieved_content']}
+{combined_retrieved_text}
 - **Images:** [Images are provided if available]
 
 **--- OUTPUT FORMAT ---**
@@ -100,28 +254,33 @@ Please format your output EXACTLY as follows for each question (do not use markd
 ---
 """
     try:
-        state["generated_questions"] = call_openai_api(prompt, state.get("document_images"))
+        generated_part = call_openai_api(prompt, image_data_urls)
+        state["final_generated_content"].append(generated_part)
     except Exception as e:
-        state["error"] = f"OpenAI API call failed: {str(e)}"
+        state["error"] = f"OpenAI API call failed during multiple_choice generation: {str(e)}"
     return state
 
-
 def generate_short_answer_node(state: ExamGenerationState) -> ExamGenerationState:
-    """Generates high-quality short-answer questions based on provided content."""
+    """Generates short-answer questions for the current task in the plan."""
     print("Node: generate_short_answer_node")
-    # TODO: The AI's role/persona could be made configurable by the user in the future.
+    current_task = state.get("current_task", {})
+    task_details = f"Task: Generate {current_task.get('count', 1)} short-answer question(s)"
+    if current_task.get('topic'):
+        task_details += f" about '{current_task.get('topic')}'"
+    combined_retrieved_text, image_data_urls = _prepare_multimodal_content(state["retrieved_page_content"])
     prompt = f"""You are a professional university professor (您是一位專業的大學教師) designing an exam. Your task is to generate high-quality short-answer questions based on the provided text content and images.
 
 **--- CRITICAL PRINCIPLES ---**
 1.  **Must Provide Answer:** Every question must have a sample correct answer.
 2.  **Must Cite Source:** For each question, you MUST specify where the answer can be found (e.g., "Source: Page 5, Paragraph 2" or "Source: Figure 1").
 3.  **Language:** All output must be in Traditional Chinese (繁體中文).
-4.  **Subject Relevance:** All questions must be strictly relevant to the main subject of the document. Filter out any questions not related to the core professional topic.
+4.  **Subject Relevance:** All questions must be strictly relevant to the main subject of the document.
 
 **--- INPUTS ---**
-- **User Query:** {state['query']}
+- **Overall User Query:** {state['query']}
+- **Current Task:** {task_details}
 - **Retrieved Content:**
-{state['retrieved_content']}
+{combined_retrieved_text}
 - **Images:** [Images are provided if available]
 
 **--- OUTPUT FORMAT ---**
@@ -134,28 +293,33 @@ Please format your output EXACTLY as follows for each question (do not use markd
 ---
 """
     try:
-        state["generated_questions"] = call_openai_api(prompt, state.get("document_images"))
+        generated_part = call_openai_api(prompt, image_data_urls)
+        state["final_generated_content"].append(generated_part)
     except Exception as e:
-        state["error"] = f"OpenAI API call failed: {str(e)}"
+        state["error"] = f"OpenAI API call failed during short_answer generation: {str(e)}"
     return state
 
-
 def generate_true_false_node(state: ExamGenerationState) -> ExamGenerationState:
-    """Generates high-quality true/false questions based on provided content."""
+    """Generates true/false questions for the current task in the plan."""
     print("Node: generate_true_false_node")
-    # TODO: The AI's role/persona could be made configurable by the user in the future.
+    current_task = state.get("current_task", {})
+    task_details = f"Task: Generate {current_task.get('count', 1)} true/false question(s)"
+    if current_task.get('topic'):
+        task_details += f" about '{current_task.get('topic')}'"
+    combined_retrieved_text, image_data_urls = _prepare_multimodal_content(state["retrieved_page_content"])
     prompt = f"""You are a professional university professor (您是一位專業的大學教師) designing an exam. Your task is to generate high-quality true/false questions based on the provided text content and images.
 
 **--- CRITICAL PRINCIPLES ---**
 1.  **Must Provide Correct Answer:** Every question must have a clearly indicated correct answer (True or False).
 2.  **Must Cite Source:** For each question, you MUST specify where the answer can be found (e.g., "Source: Page 5, Paragraph 2" or "Source: Figure 1").
 3.  **Language:** All output must be in Traditional Chinese (繁體中文).
-4.  **Subject Relevance:** All questions must be strictly relevant to the main subject of the document. Filter out any questions not related to the core professional topic.
+4.  **Subject Relevance:** All questions must be strictly relevant to the main subject of the document.
 
 **--- INPUTS ---**
-- **User Query:** {state['query']}
+- **Overall User Query:** {state['query']}
+- **Current Task:** {task_details}
 - **Retrieved Content:**
-{state['retrieved_content']}
+{combined_retrieved_text}
 - **Images:** [Images are provided if available]
 
 **--- OUTPUT FORMAT ---**
@@ -168,31 +332,15 @@ Please format your output EXACTLY as follows for each question (do not use markd
 ---
 """
     try:
-        state["generated_questions"] = call_openai_api(prompt, state.get("document_images"))
+        generated_part = call_openai_api(prompt, image_data_urls)
+        state["final_generated_content"].append(generated_part)
     except Exception as e:
-        state["error"] = f"OpenAI API call failed: {str(e)}"
+        state["error"] = f"OpenAI API call failed during true_false generation: {str(e)}"
     return state
-
 
 def handle_error_node(state: ExamGenerationState) -> ExamGenerationState:
     """Handles any errors that occurred during the process."""
     print(f"Node: handle_error_node. Error: {state['error']}")
+    state["generation_plan"] = []
+    state["final_generated_content"].append(f"An error occurred: {state['error']}")
     return state
-
-
-def route_generation_task_node(state: ExamGenerationState) -> str:
-    """Decides the next step based on errors or the requested question type."""
-    print("Node: route_generation_task_node")
-    if state["error"]:
-        return "handle_error"
-
-    question_type = state.get("question_type")
-    if question_type == "multiple_choice":
-        return "generate_multiple_choice"
-    elif question_type == "short_answer":
-        return "generate_short_answer"
-    elif question_type == "true_false":
-        return "generate_true_false"
-    else:
-        state["error"] = f"Unsupported question type: {question_type}"
-        return "handle_error"

--- a/backend/app/agents/material_generator/graph.py
+++ b/backend/app/agents/material_generator/graph.py
@@ -2,52 +2,58 @@ from langgraph.graph import StateGraph, END
 from dotenv import load_dotenv
 from .state import ExamGenerationState
 
-# Load environment variables from .env file
-# This should be at the very top of your application's entry point
 load_dotenv()
 
+# Import all the necessary nodes and the new router logic
 from .exam_nodes import (
-    retrieve_chunks_node, # Changed from read_document_node
+    retrieve_chunks_node,
+    plan_generation_tasks_node,
+    prepare_next_task_node, # New node for state modification
+    should_continue_router, # New side-effect-free router
     generate_multiple_choice_node,
     generate_short_answer_node,
     generate_true_false_node,
     handle_error_node,
-    route_generation_task_node
 )
 
 # Create a new graph
 workflow = StateGraph(ExamGenerationState)
 
 # Add the nodes to the graph
-workflow.add_node("retrieve_chunks", retrieve_chunks_node) # Changed from read_document
+workflow.add_node("retrieve_chunks", retrieve_chunks_node)
+workflow.add_node("plan_generation_tasks", plan_generation_tasks_node)
+workflow.add_node("prepare_next_task", prepare_next_task_node) # Add the new node
 workflow.add_node("generate_multiple_choice", generate_multiple_choice_node)
 workflow.add_node("generate_short_answer", generate_short_answer_node)
 workflow.add_node("generate_true_false", generate_true_false_node)
 workflow.add_node("handle_error", handle_error_node)
 
-# The router node is not explicitly added with add_node, 
-# as it's used directly in the conditional edge logic.
+# --- Define the new graph structure ---
+workflow.set_entry_point("retrieve_chunks")
+workflow.add_edge("retrieve_chunks", "plan_generation_tasks")
 
-# Set the entry point
-workflow.set_entry_point("retrieve_chunks") # Changed from read_document
+# After planning, move to the new preparation node, which is the entry point of the loop
+workflow.add_edge("plan_generation_tasks", "prepare_next_task")
 
-# Add the conditional edge after the new retriever node
-# This edge uses the router function to decide the next step
+# The conditional edge now starts from the preparation node
 workflow.add_conditional_edges(
-    "retrieve_chunks", # Changed from read_document
-    route_generation_task_node,
+    "prepare_next_task",
+    should_continue_router,
     {
         "generate_multiple_choice": "generate_multiple_choice",
         "generate_short_answer": "generate_short_answer",
         "generate_true_false": "generate_true_false",
-        "handle_error": "handle_error"
+        "handle_error": "handle_error",
+        "end": END
     }
 )
 
-# Add normal edges from each generator to the end
-workflow.add_edge('generate_multiple_choice', END)
-workflow.add_edge('generate_short_answer', END)
-workflow.add_edge('generate_true_false', END)
+# After each generation task, loop back to the preparation node to get the next task
+workflow.add_edge('generate_multiple_choice', 'prepare_next_task')
+workflow.add_edge('generate_short_answer', 'prepare_next_task')
+workflow.add_edge('generate_true_false', 'prepare_next_task')
+
+# The error node leads to the end
 workflow.add_edge('handle_error', END)
 
 # Compile the graph into a runnable app
@@ -56,33 +62,80 @@ app = workflow.compile()
 # Example of how to run the graph
 if __name__ == '__main__':
     import os
+    import json
+    from app.agents.ingestion_orchestrator import process_file
 
-    # --- Configuration ---
-    # 1. Choose the question type to test below.
-    # Possible values: "multiple_choice", "short_answer", "true_false"
-    QUESTION_TYPE_TO_TEST = "true_false"
-    # 2. Specify the ID of the content to process. This would come from the database.
-    UNIQUE_CONTENT_ID_TO_TEST = 123 # Mock ID
+    print("--- End-to-End Material Generator Test Runner (Plan-and-Execute) ---")
+    
+    # --- Step 1: Ingestion ---
+    TEST_FILES_DIR = "test_files"
+    if not os.path.isdir(TEST_FILES_DIR):
+        print(f"Error: Test files directory not found at '{TEST_FILES_DIR}'.")
+        exit()
+    
+    print("\nAvailable test files:")
+    test_files = [f for f in os.listdir(TEST_FILES_DIR) if os.path.isfile(os.path.join(TEST_FILES_DIR, f))]
+    for i, f in enumerate(test_files):
+        print(f"  {i+1}: {f}")
+    
+    try:
+        file_choice = int(input("Enter the number of the file to process: ")) - 1
+        test_file_name = test_files[file_choice]
+        test_file_path = os.path.join(TEST_FILES_DIR, test_file_name)
+    except (ValueError, IndexError):
+        print("Invalid choice.")
+        exit()
 
-    # Define the initial input for the graph
+    print(f"\nProcessing file: {test_file_path}...")
+    unique_content_id = process_file(
+        file_path=test_file_path,
+        uploader_id=1, # Mock uploader
+        course_id=1,   # Mock course
+        force_reprocess=False
+    )
+
+    if not unique_content_id:
+        print("\n--- Ingestion failed. Aborting test. ---")
+        exit()
+    
+    print(f"\n--- Ingestion successful. Using unique_content_id: {unique_content_id} ---")
+
+    # --- Step 2: Generation ---
+    print("\nEnter your query (e.g., '出 3 題選擇題和 2 題是非題')")
+    user_query = input("> ")
+
     inputs = {
-        "query": f"Generate 5 {QUESTION_TYPE_TO_TEST.replace('_', ' ')} questions based on the document content.",
-        "unique_content_id": UNIQUE_CONTENT_ID_TO_TEST,
-        "question_type": QUESTION_TYPE_TO_TEST
+        "query": user_query,
+        "unique_content_id": unique_content_id,
+        "question_type": "" # This is now deprecated, but the state still has it
     }
 
-    print(f"--- Running graph for question type: '{QUESTION_TYPE_TO_TEST}' on content ID: '{UNIQUE_CONTENT_ID_TO_TEST}' ---")
+    print(f"\n--- Running generation graph for content ID: {unique_content_id} ---")
 
-    # Run the graph
     try:
         final_state = app.invoke(inputs)
 
         print("\n--- Graph execution finished ---")
-        if not final_state.get('error'):
-            print("\nGenerated Questions:")
-            print(final_state.get("generated_questions"))
+        
+        print("\n--- Retrieved Text Chunks (for debugging) ---")
+        text_chunks = final_state.get('retrieved_text_chunks', [])
+        if not text_chunks:
+            print("No text chunks were retrieved.")
         else:
+            for i, chunk in enumerate(text_chunks):
+                print(f"  Chunk {i+1}: '{chunk.get('text', '')[:100]}...'")
+        print("---------------------------------------------")
+
+        if final_state.get('error'):
             print(f"\nFinal state has an error: {final_state.get('error')}")
+        else:
+            print("\n--- Final Generated Content ---")
+            final_content_parts = final_state.get("final_generated_content", [])
+            # Join the parts for final display
+            full_output = "\n\n".join(final_content_parts)
+            print(full_output)
+            print("-----------------------------\n")
+
     except Exception as e:
         print(f"\nAn exception occurred while running the graph: {e}")
-        print("Please ensure your OPENAI_API_KEY is set correctly.")
+        print("Please ensure your API keys are set correctly and the database is accessible.")

--- a/backend/app/agents/material_generator/state.py
+++ b/backend/app/agents/material_generator/state.py
@@ -1,18 +1,28 @@
 
-from typing import TypedDict, List
+from typing import TypedDict, List, Dict, Any, Optional
 
 class ExamGenerationState(TypedDict):
-    """Defines the state for the exam generation graph."""
+    """
+    Defines the state for the exam generation graph under the new plan-and-execute architecture.
+    """
     # Inputs
     query: str
-    unique_content_id: int # New input: ID for the content to be processed
-    question_type: str  # e.g., 'multiple_choice', 'short_answer', 'true_false'
+    unique_content_id: int
     
-    # Internal state
-    retrieved_content: str # Renamed from document_content
-    document_images: List[str] # To hold base64 encoded images from the document
+    # This will be deprecated by the plan, but is kept for now.
+    question_type: str  
+
+    # --- New Architecture Fields ---
+    # Planning state
+    generation_plan: List[Dict[str, Any]] # The plan from the LLM router (e.g., [{'type': 'multiple_choice', 'count': 3}])
+    current_task: Optional[Dict[str, Any]] # The current task being executed by a generation node
     
-    # Outputs
-    generated_questions: str # Or you can use List[dict] for structured questions
-    error: str | None
+    # Retrieval state
+    retrieved_text_chunks: List[Dict[str, Any]]  # Lightweight, for debugging and planning
+    retrieved_page_content: List[Dict[str, Any]] # Heavyweight, with base64, for generation
+    
+    # Output state
+    final_generated_content: List[str] # Accumulates results from each generation task
+    
+    error: Optional[str]
 

--- a/backend/app/agents/rag_agent.py
+++ b/backend/app/agents/rag_agent.py
@@ -1,0 +1,140 @@
+
+import os
+from typing import List, Dict, Any, Tuple
+from sqlalchemy import create_engine, text, MetaData, Table, select
+from dotenv import load_dotenv
+
+from app.services.embedding_service import embedding_service
+
+# --- Database Setup ---
+load_dotenv()
+DATABASE_URL = os.getenv("DATABASE_URL")
+if not DATABASE_URL:
+    raise ValueError("DATABASE_URL environment variable not set.")
+
+engine = create_engine(DATABASE_URL)
+metadata = MetaData()
+
+# Reflect existing tables
+document_chunks = Table('document_chunks', metadata, autoload_with=engine)
+document_content = Table('document_content', metadata, autoload_with=engine)
+
+
+class RAGAgent:
+    """
+    Agent for performing Retrieval-Augmented Generation tasks.
+    """
+
+    def search(self, user_prompt: str, unique_content_id: int, top_k: int = 5) -> Dict[str, List[Dict[str, Any]]]:
+        """
+        Performs a multi-modal RAG search and returns a dictionary separating
+        text chunks from full page content.
+
+        Args:
+            user_prompt: The user's query.
+            unique_content_id: The ID of the specific document to search within.
+            top_k: The number of top similar chunks to retrieve.
+
+        Returns:
+            A dictionary with two keys:
+            - "text_chunks": A list of lightweight text chunks for debugging/planning.
+            - "page_content": A list of heavyweight structured page content for generation.
+        """
+        print(f"--- RAGAgent: Starting Search for prompt: '{user_prompt}' within document ID: {unique_content_id} ---")
+
+        # Step 1: Vector Search (Text RAG)
+        print(f"RAGAgent: Step 1 - Performing vector search for top {top_k} chunks...")
+        query_embedding = embedding_service.create_embeddings([user_prompt])[0]
+
+        stmt = text(f"""
+            SELECT id, chunk_text, metadata
+            FROM {document_chunks.name}
+            WHERE unique_content_id = :unique_content_id
+            ORDER BY embedding <=> :query_embedding
+            LIMIT :top_k
+        """)
+
+        with engine.connect() as conn:
+            similar_chunks_results = conn.execute(
+                stmt,
+                {"query_embedding": str(query_embedding), "unique_content_id": unique_content_id, "top_k": top_k}
+            ).fetchall()
+
+        if not similar_chunks_results:
+            print("RAGAgent: No similar chunks found for the given document ID.")
+            return {"text_chunks": [], "page_content": []}
+        
+        print(f"RAGAgent: Found {len(similar_chunks_results)} similar chunks.")
+
+        # Process found text chunks for debugging and to find page numbers
+        found_text_chunks = []
+        page_numbers_to_retrieve = set()
+        for chunk in similar_chunks_results:
+            chunk_id, chunk_text, meta = chunk
+            page_numbers = meta.get("page_numbers", [])
+            page_numbers_to_retrieve.update(page_numbers)
+            found_text_chunks.append({
+                "chunk_id": chunk_id,
+                "text": chunk_text,
+                "source_pages": page_numbers
+            })
+
+        # Step 2 & 3: Retrieve Full Multimodal Content
+        print("RAGAgent: Step 2 & 3 - Retrieving full multimodal content for relevant pages...")
+        found_page_content = []
+        if page_numbers_to_retrieve:
+            print(f"RAGAgent: Querying structured content for document ID {unique_content_id}, pages: {list(page_numbers_to_retrieve)}")
+            
+            page_numbers_str = ", ".join(map(str, page_numbers_to_retrieve))
+            content_stmt = text(f"""
+                SELECT page_number, structured_content
+                FROM {document_content.name}
+                WHERE unique_content_id = :unique_content_id AND page_number IN ({page_numbers_str})
+                ORDER BY page_number
+            """)
+            
+            with engine.connect() as conn:
+                retrieved_pages = conn.execute(content_stmt, {"unique_content_id": unique_content_id}).fetchall()
+
+            for page in retrieved_pages:
+                page_num, structured_data = page
+                found_page_content.append({
+                    "type": "structured_page_content",
+                    "source_document_id": unique_content_id,
+                    "page_number": page_num,
+                    "content": structured_data
+                })
+        
+        print("RAGAgent: --- Search Finished ---")
+        return {
+            "text_chunks": found_text_chunks,
+            "page_content": found_page_content
+        }
+
+# Singleton instance for easy access
+rag_agent = RAGAgent()
+
+if __name__ == '__main__':
+    # Example usage:
+    # Ensure you have run the ingestion_orchestrator first to populate data
+    # from app.agents.ingestion_orchestrator import process_file
+    # process_file(file_path="test_files/sample2.pdf", uploader_id=1, course_id=1, force_reprocess=True)
+    
+    # Mock a unique_content_id that exists in your DB after ingestion
+    # You might need to manually find an ID from your 'unique_contents' table
+    MOCK_UNIQUE_CONTENT_ID = 1 # Replace with an actual ID from your DB
+    
+    if MOCK_UNIQUE_CONTENT_ID == 1:
+        print("WARNING: MOCK_UNIQUE_CONTENT_ID is still 1. Please replace with an actual ID from your 'unique_contents' table for a real test.")
+
+    test_prompt = "What is the role of a Principal Investigator in clinical trials?"
+    
+    if MOCK_UNIQUE_CONTENT_ID:
+        search_result = rag_agent.search(test_prompt, MOCK_UNIQUE_CONTENT_ID)
+        
+        import json
+        print("\n--- RAGAgent Search Result ---")
+        print(json.dumps(search_result, indent=2, ensure_ascii=False))
+        print("-----------------------------\n")
+    else:
+        print("Skipping RAGAgent test as MOCK_UNIQUE_CONTENT_ID is not set.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ jsonschema-specifications==2025.9.1
 langchain-classic==1.0.0
 langchain-community==0.4
 langchain-core==1.0.0
+langchain-openai==0.2.5
 langchain-text-splitters==1.0.0
 langgraph==1.0.0
 langgraph-checkpoint==2.1.2


### PR DESCRIPTION
### feat(material_generator): Implement RAG pipeline and upgrade graph to plan-and-execute agent

這是一次對 `material_generator` 進行的重大架構重構，主要目標為：

1. **架設多模態RAG**，使RAG能正確讀取Ingestion Pipeline儲存的參考資料，並進行後續教材生成。 
2. **升級為 Plan-and-Execute Agent**：將原本僵化的 Graph 升級為一個「任務迴圈」架構，使其能夠解析自然語言查詢（例如 "出 3 題選擇題和 2 題是非題"）並執行多個任務。
#### 1. Plan-and-Execute Agent

* **`graph.py`**：修改了 `StateGraph` 的結構。
    * 新增 `plan_generation_tasks` 節點作為「智慧路由 (LLM-as-a-router)」，負責解析 `user_query` 並生成「任務清單」。
    * 新增 `should_continue_router` 節點來控制迴圈，使其能依序執行任務清單中的所有任務。
    * 將 `generate_...` 節點的出口指回 `plan_generation_tasks`（或 `should_continue_router`），形成一個完整的任務執行迴圈。
* **`exam_nodes.py`**：
    * 新增了 `plan_generation_tasks_node`，它會呼叫 LLM (並使用 JSON 模式) 來生成 `generation_plan`。
    * 新增了 `should_continue_router` 函數，負責從 `generation_plan` 列表中 `pop` 任務並導向正確的生成節點。
* **`state.py`**：
    * **(關鍵)** 將 `retrieved_context` 拆分為 `retrieved_text_chunks`（輕量，用於規劃和除錯）和 `retrieved_page_content`（龐大，用於生成），解決了資料冗餘問題。
    * 新增 `generation_plan` (list) 和 `final_generated_content` (list) 欄位來支援新的迴圈架構。

#### 2. 多模態 RAG 重構與優化

* **`app/agents/rag_agent.py` (新檔案)**：
    * 建立了全新的 `RAGAgent` 類別，將檢索邏輯（向量搜尋 + 抓取 `structured_content`）從 `exam_nodes.py` 中完全分離，符合單一職責。
* **`exam_nodes.py`**：
    * **(Bug Fix)** `_prepare_multimodal_content` 現已能正確處理資料庫中儲存的 `data:image...` 完整前綴，解決了 `400` 錯誤。
    * **(Source 優化)** 重寫 `_prepare_multimodal_content` 以採用「**來源注入 (Source Injection)**」策略。
    * 此策略會將頁碼（例如 `[START] Source: Page 5`）和圖片標籤（例如 `[Image 1 is here]`）**直接注入**到傳送給 LLM 的文字上下文中。
    * **(Prompt 優化)** 同時更新了所有 `generate_..._node` 的 Prompt，**強制** LLM 必須使用這些注入的標籤來生成精確的「出處」。

#### 3. 依賴與其他

* **`requirements.txt`**：已更新，可能包含了 `langchain-openai` 等新依賴，為後續將原生 `OpenAI` client 替換為 LangChain 封裝（以實現 LangSmith 追蹤）做好準備。