### PR TITLE
feat(exam_agents): implement aggregate node, migrate logs to JSONB

### DIFF
--- a/backend/app/agents/teacher_agent/skills/exam_generator/graph.py
+++ b/backend/app/agents/teacher_agent/skills/exam_generator/graph.py
@@ -1,6 +1,7 @@
 from langgraph.graph import StateGraph, END
 from dotenv import load_dotenv
 from .state import ExamGenerationState
+from backend.app.utils import db_logger # Import db_logger
 
 load_dotenv()
 
@@ -14,6 +15,7 @@ from .exam_nodes import (
     generate_multiple_choice_node,
     generate_short_answer_node,
     generate_true_false_node,
+    aggregate_final_output_node, # Import the new aggregation node
     handle_error_node,
 )
 
@@ -27,6 +29,7 @@ workflow.add_node("prepare_next_task", prepare_next_task_node) # Add the new nod
 workflow.add_node("generate_multiple_choice", generate_multiple_choice_node)
 workflow.add_node("generate_short_answer", generate_short_answer_node)
 workflow.add_node("generate_true_false", generate_true_false_node)
+workflow.add_node("aggregate_final_output", aggregate_final_output_node) # Add the new aggregation node
 workflow.add_node("handle_error", handle_error_node)
 
 # --- Define the new graph structure ---
@@ -45,7 +48,7 @@ workflow.add_conditional_edges(
         "generate_short_answer": "generate_short_answer",
         "generate_true_false": "generate_true_false",
         "handle_error": "handle_error",
-        "end": END
+        "end": "aggregate_final_output" # Point to the aggregation node
     }
 )
 
@@ -53,6 +56,9 @@ workflow.add_conditional_edges(
 workflow.add_edge('generate_multiple_choice', 'prepare_next_task')
 workflow.add_edge('generate_short_answer', 'prepare_next_task')
 workflow.add_edge('generate_true_false', 'prepare_next_task')
+
+# The aggregation node leads to the end
+workflow.add_edge('aggregate_final_output', END)
 
 # The error node leads to the end
 workflow.add_edge('handle_error', END)

--- a/backend/app/agents/teacher_agent/skills/exam_generator/state.py
+++ b/backend/app/agents/teacher_agent/skills/exam_generator/state.py
@@ -13,5 +13,6 @@ class ExamGenerationState(TypedDict):
     generation_plan: List[Dict[str, Any]]
     current_task: Optional[Dict[str, Any]]
     final_generated_content: List[str]
+    generation_errors: List[Dict[str, Any]] # New field to store errors from individual generation tasks
     error: Optional[str]
     parent_task_id: Optional[int] # The ID of the parent task for hierarchical logging

--- a/db_migrations/versions/6f71973b4903_migrate_agent_task_in_output_to_jsonb.py
+++ b/db_migrations/versions/6f71973b4903_migrate_agent_task_in_output_to_jsonb.py
@@ -1,0 +1,118 @@
+"""migrate agent_task in, output to jsonb
+
+Revision ID: 6f71973b4903
+Revises: acfe2cfc333b
+Create Date: 2025-11-16 17:01:39.077682
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '6f71973b4903'
+down_revision: Union[str, Sequence[str], None] = 'acfe2cfc333b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    print("--- [Cook.ai] UPGRADE: Migrating AGENT_TASKS in&output columns to JSONB ---")
+
+    # 建立一個暫時的 "安全轉換" 輔助函數
+    print("Creating temporary function public.safe_cast_to_jsonb()...")
+    op.execute("""
+    CREATE OR REPLACE FUNCTION public.safe_cast_to_jsonb(text_data TEXT)
+    RETURNS JSONB AS $$
+    BEGIN
+        -- 步驟 A: 嘗試將單引號替換成雙引號，然後轉換
+        RETURN REPLACE(text_data, '''', '"')::jsonb;
+    EXCEPTION
+        -- 步驟 B: 如果轉換失敗 (例如 "invalid input syntax" 錯誤)
+        WHEN invalid_text_representation THEN
+            -- 將整筆原始的「髒資料」包裝成一個 {"message": "..."} 物件
+            RETURN jsonb_build_object('corrupted_message', text_data);
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+
+    # 移 AGENT_TASKS.task_input 欄位 (JSON -> JSONB)
+    print("Migrating column: AGENT_TASKS.task_input (JSON -> JSONB) with safety net...")
+    op.execute("""
+    ALTER TABLE AGENT_TASKS
+    ALTER COLUMN task_input
+    TYPE JSONB
+    USING (
+        public.safe_cast_to_jsonb(task_input::text) -- 先轉成 text 再傳入
+    );
+    """)
+
+    # 遷移 AGENT_TASKS.output 欄位 (TEXT -> JSONB)
+    print("Migrating column: AGENT_TASKS.output (TEXT -> JSONB) with safety net...")
+    op.execute("""
+    ALTER TABLE AGENT_TASKS
+    ALTER COLUMN output
+    TYPE JSONB
+    USING (
+      CASE
+        WHEN output IS NULL THEN NULL
+        
+        -- 情況 B: 如果是 JSON-like 字串 (用 { 或 [ 開頭)
+        WHEN TRIM(output) LIKE '{%' OR TRIM(output) LIKE '[%' THEN
+          public.safe_cast_to_jsonb(output) -- 使用安全函數
+          
+        -- 情況 C: 其他所有情況 (例如 "Retrieved 3 chunks.")
+        ELSE
+          jsonb_build_object('message', output)
+      END
+    );
+    """)
+    
+    # 遷移 GENERATED_CONTENTS.content 欄位 (JSON -> JSONB)
+    print("Migrating column: GENERATED_CONTENTS.content (JSON -> JSONB) with safety net...")
+    op.execute("""
+    ALTER TABLE GENERATED_CONTENTS
+    ALTER COLUMN content
+    TYPE JSONB
+    USING (
+        -- 【修正】使用統一的函數名稱
+        public.safe_cast_to_jsonb(content::text)
+    );
+    """)
+    
+    # 刪除暫時的輔助函數
+    print("Dropping temporary function public.safe_cast_to_jsonb()...")
+    op.execute("DROP FUNCTION public.safe_cast_to_jsonb(TEXT);")
+
+    print("--- [Cook.ai] UPGRADE for 'migrate_agent_tasks_to_jsonb' COMPLETED ---")
+
+
+def downgrade() -> None:
+    print("--- [Cook.ai] DOWNGRADE: Reverting AGENT_TASKS columns to original types ---")
+    
+    # 將 'output' 欄位從 JSONB 還原回 TEXT (原始型別是 TEXT)
+    op.alter_column('AGENT_TASKS', 'output',
+            existing_type=postgresql.JSONB(astext_type=sa.Text()),
+            type_=sa.TEXT(),
+            nullable=True)
+            
+    # 將 'task_input' 欄位從 JSONB 還原回 JSON (原始型別是 JSON)
+    op.alter_column('AGENT_TASKS', 'task_input',
+            existing_type=postgresql.JSONB(astext_type=sa.Text()),
+            type_=sa.JSON(),
+            nullable=True)
+
+    # 將 'GENERATED_CONTENTS.content' 欄位從 JSONB 還原回 JSON
+    op.alter_column('GENERATED_CONTENTS', 'content',
+            existing_type=postgresql.JSONB(astext_type=sa.Text()),
+            type_=sa.JSON(),
+            nullable=False)
+
+    # 4. 清理在 upgrade 時建立的暫存輔助函數
+    print("Dropping temporary function public.safe_cast_to_jsonb() if it exists...")
+    op.execute("DROP FUNCTION IF EXISTS public.safe_cast_to_jsonb(TEXT);")
+
+    print("--- [Cook.ai] DOWNGRADE for 'migrate_agent_tasks_to_jsonb' COMPLETED ---")


### PR DESCRIPTION
### feat(exam_agents): implement aggregate node, migrate logs to JSONB
**完成事項**
    1. 開發exam_generator的agregate node
    2. 確認確認api/ingestion能正確輸出(json格式)並紀錄logs
    3. 將資料庫agent_tasks表中的input, output和generated_contents中的content等欄位格式轉換成**jsonb**，確保之後前端渲染或critic評估時拿的到好處理的資料(資料庫遷移腳本: `6f71973b4903_migrate_agent_task_in_output_to_jsonb`)

**發現問題**
- 假設我個工作流程會呼叫mc_generator和tf_generator，如果其中一個agent成功生成，另一個失敗，是可以在agnet_tasks裡找到error_message，但輸出的時候會自己少一半，且orchestrator_job也不會有紀錄，是不是應該將特定agent的錯誤浮出給orchestrator紀錄，也以便日後做critic? 我覺得即使只有一半成功，這些結果還是可以照目前的流程回傳回來，不用直接打斷，目前在各別的agents有被紀錄成failed即可，job的地方可能可以紀錄成"警告"之類的status? 不一定要是failed，但錯誤要傳遞出來倒是真的，也可以一並在aggregate的地方附加"某某題型生成失敗，可以再次嘗試"之類的，之後再前端考慮要怎麼渲染
- 現在的agent如果遇到沒有預先定義好的exam_template，如填充題，他會硬扣到簡答題身上

 **待辦事項** 
    1. 加強agents間的error handling與傳遞
    2. 將生成結果接到前端渲染